### PR TITLE
Use output handlers

### DIFF
--- a/lib/critical/metric_base.rb
+++ b/lib/critical/metric_base.rb
@@ -360,7 +360,12 @@ module Critical
     def expect(status_on_failure=nil, &block)
       status_on_failure ||= :critical
       begin
-        update_status(status_on_failure) unless instance_eval(&block)
+        if instance_eval(&block)
+          report.expectation_succeeded
+        else
+          update_status(status_on_failure)
+          report.expectation_failed
+        end
       rescue Exception => e
         update_status(status_on_failure)
       end

--- a/lib/critical/metric_base.rb
+++ b/lib/critical/metric_base.rb
@@ -327,9 +327,7 @@ module Critical
       assert_collection_block_or_command_exists!
       @output_handler.collected_at = Time.new
       @output_handler.metric = self
-      report.collection_started
       run_processing_block
-      report.collection_completed
     end
 
     # Returns the result of running the collection command or code
@@ -412,12 +410,14 @@ module Critical
 
     def run_collection_command_or_block
       begin
+        report.collection_started
         result =
           if collection_command?
             `#{collection_command}`
           else
             instance_eval(&collection_block)
           end
+        report.collection_completed
       rescue Exception => e
         update_status(:critical)
         report.collection_failed(e)

--- a/lib/critical/metric_base.rb
+++ b/lib/critical/metric_base.rb
@@ -328,6 +328,7 @@ module Critical
       @output_handler.collected_at = Time.new
       @output_handler.metric = self
       run_processing_block
+      @output_handler.collection_completed
     end
 
     # Returns the result of running the collection command or code

--- a/lib/critical/metric_base.rb
+++ b/lib/critical/metric_base.rb
@@ -327,9 +327,9 @@ module Critical
       assert_collection_block_or_command_exists!
       @output_handler.collected_at = Time.new
       @output_handler.metric = self
-      @output_handler.collection_started
+      report.collection_started
       run_processing_block
-      @output_handler.collection_completed
+      report.collection_completed
     end
 
     # Returns the result of running the collection command or code

--- a/lib/critical/metric_base.rb
+++ b/lib/critical/metric_base.rb
@@ -327,6 +327,7 @@ module Critical
       assert_collection_block_or_command_exists!
       @output_handler.collected_at = Time.new
       @output_handler.metric = self
+      @output_handler.collection_started
       run_processing_block
       @output_handler.collection_completed
     end

--- a/lib/critical/output_handler/base.rb
+++ b/lib/critical/output_handler/base.rb
@@ -43,10 +43,10 @@ module Critical
       def processing_failed(error, message=nil, trace=nil)
       end
 
-      def expectation_failed(error, message=nil, trace=nil)
+      def expectation_failed(error=nil, message=nil, trace=nil)
       end
 
-      def expectation_succeeded(error, message=nil, trace=nil)
+      def expectation_succeeded(error=nil, message=nil, trace=nil)
       end
 
       def collection_completed(*args)

--- a/spec/unit/metric_base_spec.rb
+++ b/spec/unit/metric_base_spec.rb
@@ -250,7 +250,7 @@ describe MetricBase do
         @metric_spec.processing_block = Proc.new { 'here I come' }
         @metric.processing_block.call.should == 'here I come'
       end
-
+      
       it "passes itself into the handler block if a block with arity 1 is given" do
         @metric_class.collects { :some_data }
         @metric_spec.processing_block = Proc.new { |m| m.snitch= :yoshitoshi}
@@ -391,6 +391,22 @@ describe MetricBase do
         @metric.result
       end
       
+      describe "reporting on expectations" do
+        
+        it "notifies the output handler when an expectation fails" do
+          @output_handler.should_receive(:expectation_failed)
+          @metric_spec.processing_block = Proc.new { expect {false} }
+          @metric.collect(@output_handler, @trending_handler)
+        end
+
+        it "notifies the output handler when an expectation succeeds" do
+          @output_handler.should_receive(:expectation_succeeded)
+          @metric_spec.processing_block = Proc.new { expect {true} }
+          @metric.collect(@output_handler, @trending_handler)
+        end
+
+      end
+
       describe "classifying the state of the monitored property" do
 
         it "reports expectation failures as critical" do
@@ -398,7 +414,7 @@ describe MetricBase do
           @metric.collect(@output_handler, @trending_handler)
           @metric.metric_status.should == :critical
         end
-
+        
         it "reports expectation failures as warning when given :warning as the argument" do
           @metric_spec.processing_block = Proc.new { expect(:warning) {false} }
           @metric.collect(@output_handler, @trending_handler)

--- a/spec/unit/metric_base_spec.rb
+++ b/spec/unit/metric_base_spec.rb
@@ -295,6 +295,12 @@ describe MetricBase do
     end
 
     describe "executing the collection command" do
+      
+      it "notifies the output handler that collection has started" do
+        @metric_class.collects("echo 'noop'")
+        @output_handler.should_receive(:collection_started)
+        @metric.collect(@output_handler, @trending_handler)
+      end
 
       it "runs the command and returns the result" do
         @metric_class.collects("echo 'a random string'")
@@ -354,7 +360,6 @@ describe MetricBase do
           lambda { @metric.collect(@output_handler) }.should_not raise_exception
         end
       end
-
     end
 
     describe "reporting the results of collection" do

--- a/spec/unit/metric_base_spec.rb
+++ b/spec/unit/metric_base_spec.rb
@@ -184,14 +184,16 @@ describe MetricBase do
 
     describe "defining reporting methods" do
       before do
-        @metric_class.collects { 'the answer is 42'}
+        @metric_class.collects { 'the answer is 42' }
+        # The output handler needs to be set or calling result will blow up.
+        @metric.collect(@output_handler, @trending_handler)
       end
 
       it "defines a method for reporting results" do
         @metric_class.add_reporting_method(:answer) do
           /([\d]+)$/.match(result).captures.first
         end
-         @metric.answer.should == '42'
+        @metric.answer.should == '42'
       end
 
       it "coerces output into a float" do
@@ -300,6 +302,7 @@ describe MetricBase do
         @metric_class.collects("echo 'noop'")
         @output_handler.should_receive(:collection_started)
         @metric.collect(@output_handler, @trending_handler)
+        @metric.result
       end
 
       it "runs the command and returns the result" do
@@ -385,6 +388,7 @@ describe MetricBase do
       it "notifies the output handler when collection is complete" do
         @output_handler.should_receive(:collection_completed)
         @metric.collect(@output_handler, @trending_handler)
+        @metric.result
       end
       
       describe "classifying the state of the monitored property" do

--- a/spec/unit/metric_base_spec.rb
+++ b/spec/unit/metric_base_spec.rb
@@ -376,7 +376,12 @@ describe MetricBase do
         @metric.collect(@output_handler, @trending_handler)
         report_during_collection.collected_at.should == now
       end
-
+      
+      it "notifies the output handler when collection is complete" do
+        @output_handler.should_receive(:collection_completed)
+        @metric.collect(@output_handler, @trending_handler)
+      end
+      
       describe "classifying the state of the monitored property" do
 
         it "reports expectation failures as critical" do


### PR DESCRIPTION
This should cause metrics to notify output handlers on all the events that are implemented in Critical::OutputHandler::Base. I'm not sure how useful some of them are, but my assumption is that once the handler has been notified it can interrogate the metric instance for details on the circumstances around failures.
